### PR TITLE
Hotfix: post-package-install event on all installed packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --no-plugins"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit symfony/console symfony/filesystem symfony/finder symfony/process"
+        - LEGACY_DEPS="phpunit/phpunit symfony/console symfony/filesystem symfony/finder symfony/process zendframework/zend-component-installer"
     - php: 5.6
       env:
         - DEPS=latest
@@ -27,7 +27,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit symfony/console symfony/filesystem symfony/finder symfony/process"
+        - LEGACY_DEPS="phpunit/phpunit symfony/console symfony/filesystem symfony/finder symfony/process zendframework/zend-component-installer"
     - php: 7
       env:
         - DEPS=latest

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "composer-plugin-api": "^1.0",
-        "zendframework/zend-component-installer": "^1.0"
+        "zendframework/zend-component-installer": "^1.0 || ^2.1.2"
     },
     "require-dev": {
         "composer/composer": "^1.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,38 +4,38 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de24f19bf99828fa522c359d9ba1609b",
+    "content-hash": "35336e3d24d9a304e53f1ff4fe74d587",
     "packages": [
         {
             "name": "zendframework/zend-component-installer",
-            "version": "1.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-component-installer.git",
-                "reference": "5e9beda3b81d29d4d080b110d67f8c8c44d93605"
+                "reference": "56871c43e40f92324b25d5a4d50ff51f9f556910"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-component-installer/zipball/5e9beda3b81d29d4d080b110d67f8c8c44d93605",
-                "reference": "5e9beda3b81d29d4d080b110d67f8c8c44d93605",
+                "url": "https://api.github.com/repos/zendframework/zend-component-installer/zipball/56871c43e40f92324b25d5a4d50ff51f9f556910",
+                "reference": "56871c43e40f92324b25d5a4d50ff51f9f556910",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
                 "composer/composer": "^1.5.2",
                 "malukenho/docheader": "^0.1.6",
-                "mikey179/vfsstream": "^1.6.5",
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "mikey179/vfsstream": "^1.6.7",
+                "phpunit/phpunit": "^7.5.15 || ^8.3.4",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev",
-                    "dev-develop": "1.2-dev"
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev"
                 },
                 "class": "Zend\\ComponentInstaller\\ComponentInstaller"
             },
@@ -48,7 +48,7 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Composer plugin for automating component registration in zend-mvc and Expressive applications",
+            "description": "Composer plugin for injecting modules and configuration providers into application configuration",
             "keywords": [
                 "ZendFramework",
                 "component installer",
@@ -56,7 +56,7 @@
                 "plugin",
                 "zf"
             ],
-            "time": "2018-01-11T15:03:06+00:00"
+            "time": "2019-09-04T19:10:43+00:00"
         }
     ],
     "packages-dev": [
@@ -1278,6 +1278,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-04-11T04:50:36+00:00"
         },
         {

--- a/src/BroadcastEventDispatcher.php
+++ b/src/BroadcastEventDispatcher.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-skeleton-installer for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-skeleton-installer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\SkeletonInstaller;
+
+use Composer\Composer;
+use Composer\EventDispatcher\Event;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\IO\IOInterface;
+use Composer\Util\ProcessExecutor;
+
+class BroadcastEventDispatcher extends EventDispatcher
+{
+    /** @var null|EventDispatcher */
+    private $eventDispatcher;
+
+    /** @var string[] */
+    private $broadcastEvents;
+
+    /**
+     * @param EventDispatcher|null $eventDispatcher EventDispatcher of original Composer process
+     * @param string[] $broadcastEvents List of events we want to pass to original EventDispatcher
+     */
+    public function __construct(
+        Composer $composer,
+        IOInterface $io,
+        ProcessExecutor $process = null,
+        EventDispatcher $eventDispatcher = null,
+        array $broadcastEvents = []
+    ) {
+        parent::__construct($composer, $io, $process);
+
+        $this->eventDispatcher = $eventDispatcher;
+        $this->broadcastEvents = $broadcastEvents;
+    }
+
+    protected function doDispatch(Event $event)
+    {
+        if ($this->eventDispatcher && in_array($event->getName(), $this->broadcastEvents, true)) {
+            return $this->eventDispatcher->doDispatch($event);
+        }
+
+        return parent::doDispatch($event);
+    }
+}

--- a/test/BroadcastEventDispatcherTest.php
+++ b/test/BroadcastEventDispatcherTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-skeleton-installer for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-skeleton-installer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\SkeletonInstaller;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Zend\SkeletonInstaller\BroadcastEventDispatcher;
+
+class BroadcastEventDispatcherTest extends TestCase
+{
+    /** @var Composer|ObjectProphecy */
+    private $composer;
+
+    /** @var IOInterface|ObjectProphecy */
+    private $io;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->composer = $this->prophesize(Composer::class);
+        $this->io = $this->prophesize(IOInterface::class);
+    }
+
+    public function testBroadcastEvent()
+    {
+        $originEventDispatcher = new TestAsset\OriginEventDispatcher(
+            $this->composer->reveal(),
+            $this->io->reveal()
+        );
+        $broadcastEventDispatcher = new BroadcastEventDispatcher(
+            $this->composer->reveal(),
+            $this->io->reveal(),
+            null,
+            $originEventDispatcher,
+            ['my-custom-event']
+        );
+
+        // Hard to mock everything for that test...
+        // $broadcastEventDispatcher->dispatch('other-event');
+        // self::assertCount(0, $originEventDispatcher->dispatchedEvents);
+
+        $broadcastEventDispatcher->dispatch('my-custom-event');
+        self::assertCount(1, $originEventDispatcher->dispatchedEvents);
+        self::assertSame('my-custom-event', $originEventDispatcher->dispatchedEvents[0]->getName());
+    }
+}

--- a/test/TestAsset/OriginEventDispatcher.php
+++ b/test/TestAsset/OriginEventDispatcher.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-skeleton-installer for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-skeleton-installer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\SkeletonInstaller\TestAsset;
+
+use Composer\EventDispatcher\Event;
+use Composer\EventDispatcher\EventDispatcher;
+
+class OriginEventDispatcher extends EventDispatcher
+{
+    /** @var Event[] */
+    public $dispatchedEvents = [];
+
+    protected function doDispatch(Event $event)
+    {
+        $this->dispatchedEvents[] = $event;
+
+        return 1;
+    }
+}


### PR DESCRIPTION
- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

As we noted yday during skeleton installation we are not prompted
for all packages to be injected into modules.

We were not prompted for in-direct dependencies, and I have discovered
in code that we submit manually event just for optional packages
and not dependencies.

As we are using different EventDispatcher (to avoid curcular calls) we need
broadcast post-package-install event to the original EventDispatcher
of the main composer process. This simplify the code a lot as we don't
need to create custom component installer.

I am aware that current tests are not complete... I did manual tests with ZF mvc application and all seems to be fine.

/cc @weierophinney 